### PR TITLE
Use discord ui views for buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ grass
 **/.vscode/
 update_ba.bash
 target/renders/levels/*
+.venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ jishaku
 git+https://github.com/Rapptz/asqlite
 discord.py>=2.0.0
 git+https://github.com/Rapptz/discord-ext-menus
+git+https://github.com/oliver-ni/discord-ext-menus-views
 charset-normalizer
 colour-science
 numpy~=1.23.3

--- a/src/cogs/utilities.py
+++ b/src/cogs/utilities.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from io import BytesIO
 from pathlib import Path
 
@@ -17,7 +16,7 @@ import zipfile
 import glob
 import discord
 from discord.ext import commands, menus
-from discord.ext.menus import button, First, Last
+from discord.ext.menus.views import ViewMenuPages
 from PIL import Image, ImageFont, ImageDraw
 
 from . import flags
@@ -106,27 +105,27 @@ class FlagPageSource(menus.ListPageSource):
 
 
 class ButtonPages(
-        menus.MenuPages,
-        inherit_buttons=False):  # TODO: make these discord.ui buttons
-    @button('⏮', position=First())
+        ViewMenuPages,
+        inherit_buttons=False):
+    @menus.button('⏮', position=menus.First())
     async def go_to_first_page(self, payload):
         await self.show_page(0)
 
-    @button('◀', position=First(1))
+    @menus.button('◀', position=menus.First(1))
     async def go_to_previous_page(self, payload):
         await self.show_checked_page(self.current_page - 1)
 
-    @button('▶', position=Last(1))
+    @menus.button('▶', position=menus.Last(1))
     async def go_to_next_page(self, payload):
         await self.show_checked_page(self.current_page + 1)
 
-    @button('⏭', position=Last(2))
+    @menus.button('⏭', position=menus.Last(2))
     async def go_to_last_page(self, payload):
         max_pages = self._source.get_max_pages()
         last_page = max(max_pages - 1, 0)
         await self.show_page(last_page)
 
-    @button('⏹', position=Last())
+    @menus.button('⏹', position=menus.Last())
     async def stop_pages(self, payload):
         self.stop()
 


### PR DESCRIPTION
This includes a new library that wraps discord.ext.menus so it just works using discord.ui buttons right out of the box

As shown:
<img width="584" alt="image" src="https://user-images.githubusercontent.com/35444188/191023300-191a3f03-fa77-413c-8147-ce7478515e87.png">
